### PR TITLE
Fix app quitting when opening the first document from the Open dialog

### DIFF
--- a/src/main.m
+++ b/src/main.m
@@ -694,7 +694,7 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
 }
 
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender {
-    return YES;
+    return NO;
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification {
@@ -830,9 +830,6 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
     [NSApp activateIgnoringOtherApps:YES];
 
     if ([panel runModal] != NSModalResponseOK) {
-        if (self.windowControllers.count == 0) {
-            [NSApp terminate:nil];
-        }
         return;
     }
 


### PR DESCRIPTION
When the app was launched without an initial document, it immediately presented the Open dialog. After selecting a file, the dialog closed before the preview window was created. Because
  the app was configured to terminate after the last window closed, AppKit could treat the closed Open dialog as leaving the app with no visible windows and quit before the selected
  document opened.

  This changes the app lifecycle so closing the last document window no longer terminates the app. It also removes the explicit termination path when the initial Open dialog is cancelled.
  With this behavior, the app can remain open without any document windows, and opening the first document from the Open dialog works the same way as opening subsequent documents or opening
  files via Finder drag/drop.

Fixes #6 