### PR TITLE
Fix File Open to add tabs instead of replacing the current document

### DIFF
--- a/src/main.m
+++ b/src/main.m
@@ -836,7 +836,7 @@ decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
         return;
     }
 
-    [self openFileURLs:panel.URLs reuseCurrentWindow:YES];
+    [self openFileURLs:panel.URLs reuseCurrentWindow:NO];
 }
 
 - (void)reloadPreview:(id)sender {


### PR DESCRIPTION
- Updated File > Open to use the same non-reuse open path as Finder/default-app launches.
- Selected Markdown files now open as new tabs/windows instead of replacing the active document.

Fixes #7 