### PR TITLE
Add click-to-copy for code blocks

### DIFF
--- a/src/Info.plist
+++ b/src/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.local.markdown-viewer</string>
     <key>CFBundleVersion</key>
-    <string>2.4.3</string>
+    <string>2.4.4</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.4.3</string>
+    <string>2.4.4</string>
     <key>CFBundleExecutable</key>
     <string>MarkdownViewer</string>
     <key>CFBundleIconFile</key>

--- a/src/viewer.css
+++ b/src/viewer.css
@@ -196,11 +196,47 @@ body {
 }
 
 .document pre {
+  position: relative;
   overflow-x: auto;
   padding: 20px 22px;
   border-radius: 14px;
   background: var(--code-block-bg);
   color: var(--code-block-text);
+}
+
+.document pre.code-block--copyable {
+  cursor: copy;
+  outline: 1px solid transparent;
+  outline-offset: 2px;
+  transition: outline-color 0.15s;
+}
+
+.document pre.code-block--copyable:hover,
+.document pre.code-block--copyable:focus-visible {
+  outline-color: var(--accent);
+}
+
+.document pre.code-block--copyable::after {
+  content: attr(data-copy-label);
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  padding: 5px 7px;
+  border: 1px solid rgba(216, 226, 240, 0.22);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.36);
+  color: var(--code-block-text);
+  font: 500 11px/1 "SF Pro Text", "Segoe UI", sans-serif;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s;
+}
+
+.document pre.code-block--copyable:hover::after,
+.document pre.code-block--copyable:focus-visible::after,
+.document pre.code-block--copyable[data-copy-state="copied"]::after,
+.document pre.code-block--copyable[data-copy-state="failed"]::after {
+  opacity: 0.88;
 }
 
 .document pre code {
@@ -258,6 +294,12 @@ body {
 .document input[type="checkbox"] {
   margin-right: 8px;
   transform: translateY(1px);
+}
+
+.clipboard-fallback-input {
+  position: fixed;
+  top: -9999px;
+  left: -9999px;
 }
 
 .theme-toggle {
@@ -391,7 +433,8 @@ body:hover .theme-toggle {
   }
 
   .theme-toggle,
-  .find-panel {
+  .find-panel,
+  .document pre.code-block--copyable::after {
     display: none;
   }
 }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -96,6 +96,7 @@
 
   function applyRenderedContent() {
     contentEl.innerHTML = renderedContentHtml || "<p></p>";
+    setupCodeBlockCopy(contentEl);
     disableTaskCheckboxes(contentEl);
     finalizeLinks(contentEl);
     finalizeImages(contentEl);
@@ -404,6 +405,106 @@
 
     for (const checkbox of checkboxes) {
       checkbox.disabled = true;
+    }
+  }
+
+  async function copyTextToClipboard(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      try {
+        await navigator.clipboard.writeText(text);
+        return;
+      } catch (error) {
+        console.warn(error);
+      }
+    }
+
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.className = "clipboard-fallback-input";
+    textarea.setAttribute("readonly", "");
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+
+    try {
+      if (!document.execCommand("copy")) {
+        throw new Error("Copy command was rejected.");
+      }
+    } finally {
+      textarea.remove();
+    }
+  }
+
+  function hasSelectionInside(element) {
+    const selection = window.getSelection();
+    if (!selection || selection.isCollapsed) {
+      return false;
+    }
+
+    return element.contains(selection.anchorNode) || element.contains(selection.focusNode);
+  }
+
+  function setCodeBlockCopyState(pre, state) {
+    pre.dataset.copyState = state;
+
+    if (state === "copied") {
+      pre.dataset.copyLabel = "Copied";
+    } else if (state === "failed") {
+      pre.dataset.copyLabel = "Copy failed";
+    } else {
+      pre.dataset.copyLabel = "Click to copy";
+    }
+  }
+
+  function flashCodeBlockCopyState(pre, state) {
+    setCodeBlockCopyState(pre, state);
+    window.clearTimeout(Number(pre.dataset.copyTimer || 0));
+
+    const timer = window.setTimeout(() => {
+      setCodeBlockCopyState(pre, "ready");
+      delete pre.dataset.copyTimer;
+    }, 1400);
+
+    pre.dataset.copyTimer = String(timer);
+  }
+
+  async function copyCodeBlock(pre, code) {
+    try {
+      await copyTextToClipboard(code.textContent || "");
+      flashCodeBlockCopyState(pre, "copied");
+    } catch (error) {
+      console.error(error);
+      flashCodeBlockCopyState(pre, "failed");
+    }
+  }
+
+  function setupCodeBlockCopy(root) {
+    const codeBlocks = root.querySelectorAll("pre > code");
+
+    for (const code of codeBlocks) {
+      const pre = code.parentElement;
+      if (!pre) continue;
+
+      pre.classList.add("code-block--copyable");
+      pre.setAttribute("role", "button");
+      pre.setAttribute("tabindex", "0");
+      pre.setAttribute("aria-label", "Copy code block");
+      setCodeBlockCopyState(pre, "ready");
+
+      pre.addEventListener("click", () => {
+        if (!hasSelectionInside(pre)) {
+          copyCodeBlock(pre, code);
+        }
+      });
+
+      pre.addEventListener("keydown", (event) => {
+        if (event.key !== "Enter" && event.key !== " ") {
+          return;
+        }
+
+        event.preventDefault();
+        copyCodeBlock(pre, code);
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- make fenced code blocks copyable with click, Enter, or Space
- preserve partial text selection by skipping copy when text is selected inside the block
- show subtle copy/copy-failed feedback on hover/focus
- bump the bundle version to 2.4.4

Fixes #9

## Verification
- node --check src/viewer.js
- plutil -lint src/Info.plist
- git diff --check
- ./build.sh archive